### PR TITLE
remove unused include

### DIFF
--- a/SDIO_HOST.c
+++ b/SDIO_HOST.c
@@ -25,7 +25,6 @@
 #include "SDIO_HOST.h"
 #include "cy_utils.h"
 #include "cy_gpio.h"
-#include "cybsp.h"
 
 #if defined(CYHAL_UDB_SDIO)
 


### PR DESCRIPTION
include is unused, removing it helps with modular compilation
